### PR TITLE
IndexListSlow: fix index comparison & assignment

### DIFF
--- a/mikktspace.c
+++ b/mikktspace.c
@@ -751,6 +751,7 @@ static void GenerateSharedVerticesIndexListSlow(int piTriList_in_and_out[], cons
 					const SVec3 vP2 = GetPosition(pContext, index2);
 					const SVec3 vN2 = GetNormal(pContext, index2);
 					const SVec3 vT2 = GetTexCoord(pContext, index2);
+					index2rec = index2;
 					
 					if (veq(vP,vP2) && veq(vN,vN2) && veq(vT,vT2))
 						bFound = TTRUE;


### PR DESCRIPTION
I was studying the code and noticed that the `IndexListSlow` generation code didn't work as expected. The index being used to compare was never recorded and as such the index list would be generated entirely with -1, which isn't valid.

I'm fairly certain this code isn't used much, if at all. Otherwise others would've complained.
Especially because malloc fails are very rare on modern systems.
Still, better to have it working if the necessity arises.